### PR TITLE
Update getRoles.js

### DIFF
--- a/Discord/Commands/getRoles.js
+++ b/Discord/Commands/getRoles.js
@@ -1,36 +1,18 @@
 module.exports = async function getRoles(
-  /** import("discord.js").Message */ msg,
-  /** Array<String> */ parametres
+    /** import("discord.js").Message */ msg,
+    /** Array<String> */ args
 ) {
-  if (parametres.length !== 3) {
-    msg
-      .reply(
-        ` :warning:  Erreur. La syntaxe est \`${process.env.BOT_PREFIX} getRoles NombreDePersonnes\`.`
-      )
-      .catch(console.error);
-  } else {
-    msg.channel
-      .send(
-        ":clock1: Cette commande peut être longue, elle affichera un message pour signaler sa fin. Si elle ne le fait pas, contacter un administrateur."
-      )
-      .then(async () => {
-        let compteur = 0;
-        (await msg.guild.roles.fetch()).forEach((role) => {
-          if (role.members.size.toString() === parametres[2].toString()) {
-            msg.channel
-              .send(
-                `Le rôle ${role.name} a ${role.members.size} utilisateur(s).`
-              )
-              .catch(console.error);
-            compteur += 1;
-          }
-        });
-        msg.channel
-          .send(
-            `:white_check_mark: Commande terminée, ${compteur} roles ont été identifiés.`
-          )
-          .catch(console.error);
-      })
-      .catch(console.error);
-  }
+    if (args.length !== 3) {
+        msg.reply(
+            ` :warning:  Erreur. La syntaxe est \`${process.env.BOT_PREFIX} getRoles NombreDePersonnes\`.`
+        ).catch(console.error);
+        return;
+    }
+    const nbMembers = parseInt(args[2]);
+    const roles = (await msg.guild.roles.fetch())
+        .filter(role => role.members.size === nbMembers)
+        .map(role => role.name);
+    await msg.channel.send(
+        `:white_check_mark: ${roles.length} roles ont été identifiés : \n -` + roles.join("\n -")
+    );
 };

--- a/Discord/Commands/getRoles.js
+++ b/Discord/Commands/getRoles.js
@@ -1,18 +1,18 @@
 module.exports = async function getRoles(
     /** import("discord.js").Message */ msg,
-    /** Array<String> */ args
+    /** Array<String> */ parametres
 ) {
-    if (args.length !== 3) {
+    if (parametres.length !== 3) {
         msg.reply(
             ` :warning:  Erreur. La syntaxe est \`${process.env.BOT_PREFIX} getRoles NombreDePersonnes\`.`
         ).catch(console.error);
         return;
     }
-    const nbMembers = parseInt(args[2]);
+    const nbMembers = parseInt(parametres[2]);
     const roles = (await msg.guild.roles.fetch())
         .filter(role => role.members.size === nbMembers)
         .map(role => role.name);
     await msg.channel.send(
-        `:white_check_mark: ${roles.length} roles ont été identifiés : \n -` + roles.join("\n -")
+        `:white_check_mark: ${roles.length} roles ont été identifiés : \n -` + roles.join(", ")
     );
 };


### PR DESCRIPTION
Réécriture complète de la fonction pour la rendre plus lisible et plus opti.
Le message pour prévenir que l'exécution de la commande peut être longue a été supprimé, pour la simple et bonne raison que c'est faux : la mise en cache des roles permet de les examiner sans avoir recours à des fonctions bloquantes. A moins d'écrire un code inefficace, l'opération se fait en un temps très faible même lorsqu'il y a beaucoup de rôles.