### PR TITLE
Refactor de la fonction `renameRole`

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -39,21 +39,19 @@ module.exports.sleep = async function sleep(ms) {
     });
 }
 
-module.exports.renameRole = async function renameRole(/** string */ roleName) {
+function renameRole(/** string */ roleName) {
     if (roleName.endsWith("A")) return roleName.substr(0, roleName.length - 1);
 
-    for (const starting of ["LS", "LE", "IT", "LG", "LC", "KO","LX"])
-        if (roleName.startsWith(starting))
-            return starting;
-
+    if (["LS", "LE", "IT", "LG", "LC", "KO","LX"].includes(roleName.substr(0, 2)))
+        return roleName.substr(0, 2);
+    
     if (roleName.startsWith("ISI_C")) return "ISI_C";
 
     if (roleName.startsWith("OCR")) return "OCR";
 
     const rolesPE = ["PEXX", "PEEE", "PEEC", "PETM", "PEME", "PEHT", "PECS"];
-    for (const starting of rolesPE)
-        if (roleName.startsWith(starting))
-            return "PE";
+    if (rolesPE.includes(roleName.substr(0, 4)))
+        return "PE";
 
     return roleName;
 };


### PR DESCRIPTION
La fonction n'a pas besoin d'être asynchrone

Remplacement des deux boucles par des appels de la méthode `includes`