### PR TITLE
Ajout de la commande certif

### DIFF
--- a/Discord/Commands/certif.js
+++ b/Discord/Commands/certif.js
@@ -1,0 +1,17 @@
+/**
+ * Répond au message de la commande avec un message indiquant
+ * comment accéder à son certificat de scolarité
+ *
+ * @param msg : String
+ * @returns {Promise<void>}
+ */
+module.exports = async function send_certif(msg) {
+    msg.reply(
+        "Comment trouver son certificat de scolarité : \n" +
+        "1. Aller sur https://ent.utt.fr/ ;\n" +
+        "2. Se connecter avec ses identifiants UTT ;\n" +
+        "3. Suivre le chemin suivant : onglet \"Formation\" --> sous-onglet \"Dossier des étudiants\" ;\n" +
+        "4. Aller dans le menu \"Mes documents administratifs\" ;\n" +
+        "5. Récupérer le document souhaité."
+    );
+}

--- a/Discord/Commands/certif.js
+++ b/Discord/Commands/certif.js
@@ -2,16 +2,16 @@
  * Répond au message de la commande avec un message indiquant
  * comment accéder à son certificat de scolarité
  *
- * @param msg : String
+ * @param msg : import("discord.js").Message
  * @returns {Promise<void>}
  */
-module.exports = async function send_certif(msg) {
-    msg.reply(
-        "Comment trouver son certificat de scolarité : \n" +
-        "1. Aller sur https://ent.utt.fr/ ;\n" +
-        "2. Se connecter avec ses identifiants UTT ;\n" +
-        "3. Suivre le chemin suivant : onglet \"Formation\" --> sous-onglet \"Dossier des étudiants\" ;\n" +
-        "4. Aller dans le menu \"Mes documents administratifs\" ;\n" +
-        "5. Récupérer le document souhaité."
-    );
-}
+module.exports = async function certif(msg) {
+  await msg.reply(
+    "Comment trouver son certificat de scolarité : \n" +
+      "1. Aller sur https://ent.utt.fr/ ;\n" +
+      "2. Se connecter avec ses identifiants UTT ;\n" +
+      '3. Suivre le chemin suivant : onglet "Formation" --> sous-onglet "Dossier des étudiants" ;\n' +
+      '4. Aller dans le menu "Mes documents administratifs" ;\n' +
+      "5. Récupérer le document souhaité."
+  );
+};

--- a/Discord/DiscordEvents/message.js
+++ b/Discord/DiscordEvents/message.js
@@ -143,6 +143,9 @@ module.exports = async function message(
         case "author":
           msg.channel.send(utils.author).catch(console.error);
           break;
+        case "certif":
+          await certif(msg);
+          break;
         default:
           if (!commandesAdmin.includes(parametres[1].toLowerCase())) {
             await discordUtils.help(msg);

--- a/Discord/DiscordEvents/message.js
+++ b/Discord/DiscordEvents/message.js
@@ -24,6 +24,7 @@ const delSameRoles = require("../Commands/delSameRoles");
 const listAnon = require("../Commands/listAnon");
 const sendAnon = require("../Commands/sendAnon");
 const addUes = require("../Commands/addUEs");
+const certif = require("../Commands/certif");
 const { getUserFromGuild } = require("../discordUtils");
 
 const { Permissions } = require("discord.js");

--- a/Discord/discordUtils.js
+++ b/Discord/discordUtils.js
@@ -39,7 +39,7 @@ module.exports.help = async function help(
         `\n\`${process.env.BOT_PREFIX} export\`. Exporte tout le channel dans lequel la commande est tapée, dans un html lisible offline. **Seuls ceux ayant un rôle >= Enseignant** peuvent taper cette commande n'importe où.` +
           `\n\`${process.env.BOT_PREFIX} joinVocal\`. Pour les étudiants, crée ou rejoint le channel vocal de l'UE correspondant au channel texte, auquel seuls les étudiants de l'UE ont accès. Pour les enseignants, crée un amphi vocal et textuel que tout le monde peut rejoindre. Si vous rajoutez \`@NOM_UE\` à la fin de la commande, crée un amphi visible seulement par vous, les étudiants de l'UE et tous les enseignants (pour faciliter les cours à plusieurs enseignants).` +
           `\n\`${process.env.BOT_PREFIX} pin messageID\`. Permet d'ajouter un message à la liste des messages pin (sans donner la permission \`MANAGE_MESSAGES\`)` +
-          `\n\`${process.env.BOT_PREFIX} unpin messageID\`. Permet de supprimer un message de la liste des messages pin (sans donner la permission \`MANAGE_MESSAGES\`)`
+          `\n\`${process.env.BOT_PREFIX} unpin messageID\`. Permet de supprimer un message de la liste des messages pin (sans donner la permission \`MANAGE_MESSAGES\`)` +
           `\n\`${process.env.BOT_PREFIX} certif\`. Envoie un message décrivant la manière de trouver son certificat de scolarité sur l'ent.`
       )
       .catch(console.error);

--- a/Discord/discordUtils.js
+++ b/Discord/discordUtils.js
@@ -40,6 +40,7 @@ module.exports.help = async function help(
           `\n\`${process.env.BOT_PREFIX} joinVocal\`. Pour les étudiants, crée ou rejoint le channel vocal de l'UE correspondant au channel texte, auquel seuls les étudiants de l'UE ont accès. Pour les enseignants, crée un amphi vocal et textuel que tout le monde peut rejoindre. Si vous rajoutez \`@NOM_UE\` à la fin de la commande, crée un amphi visible seulement par vous, les étudiants de l'UE et tous les enseignants (pour faciliter les cours à plusieurs enseignants).` +
           `\n\`${process.env.BOT_PREFIX} pin messageID\`. Permet d'ajouter un message à la liste des messages pin (sans donner la permission \`MANAGE_MESSAGES\`)` +
           `\n\`${process.env.BOT_PREFIX} unpin messageID\`. Permet de supprimer un message de la liste des messages pin (sans donner la permission \`MANAGE_MESSAGES\`)`
+          `\n\`${process.env.BOT_PREFIX} certif\`. Envoie un message décrivant la manière de trouver son certificat de scolarité sur l'ent.`
       )
       .catch(console.error);
   } else {


### PR DESCRIPTION
Proposition d'ajouter une commande `certif` pour signaler plus rapidement aux utilisateurs du discord où trouver leur certificat de scolarité (la demande est assez fréquente, mine de rien).

La commande envoie un message donnant les étapes à suivre. Le texte est celui d'Arnaud Gorce.

La commande s'utilise avec la syntaxe suivante : `\UE certif`